### PR TITLE
Bugfix for Blender 3.0

### DIFF
--- a/RenderBurst.py
+++ b/RenderBurst.py
@@ -110,7 +110,7 @@ class RenderBurst(bpy.types.Operator):
 
 # ui part
 class RbFilterSettings(bpy.types.PropertyGroup):
-    rb_filter_enum = bpy.props.EnumProperty(
+    rb_filter_enum: bpy.props.EnumProperty(
         name = "Filter",
         description = "Choose your destiny",
         items = [


### PR DESCRIPTION
Fixes the addon to work with Blender 3.0. 

This goes back to a change made in Blender 2.8, see [release notes](https://wiki.blender.org/wiki/Reference/Release_Notes/2.80/Python_API/Addons#Class_Property_Registration).